### PR TITLE
Nitpicks and suggestions for improvements

### DIFF
--- a/mygmp.c
+++ b/mygmp.c
@@ -123,8 +123,15 @@ PHP_FUNCTION(mygmp_random_ints) {
     }
 }
 
+static zend_class_entry *mygmp_ce;
+
+PHP_METHOD(MyGMP, __construct) {
+    // TODO...
+}
+
 static PHP_MINIT_FUNCTION(mygmp) {
     gmp_randinit_mt(randstate);
+    mygmp_ce = register_class_MyGMP();
     return SUCCESS;
 }
 

--- a/mygmp.c
+++ b/mygmp.c
@@ -58,7 +58,7 @@ PHP_FUNCTION(mygmp_add_array) {
     b = zend_symtable_str_find(arr, "b", strlen("b"));
     if (!a || (Z_TYPE_P(a) != IS_STRING) || !b || (Z_TYPE_P(b) != IS_STRING)) {
         php_error(E_WARNING, "Invalid or missing elements");
-        return;
+        RETURN_NULL();
     }
 
     do_mygmp_add(return_value, Z_STR_P(a), Z_STR_P(b));

--- a/mygmp.c
+++ b/mygmp.c
@@ -138,7 +138,27 @@ static mygmp_object* mygmp_from_zend_object(zend_object* zobj)
     { return ((mygmp_object*)(zobj + 1)) - 1; }
 
 PHP_METHOD(MyGMP, __construct) {
-    // TODO...
+    mygmp_object *objval = mygmp_from_zend_object(Z_OBJ_P(getThis()));
+    zval *initval = NULL;
+
+    if (zend_parse_parameters_throw(ZEND_NUM_ARGS(), "|z!", &initval) == FAILURE) {
+        return;
+    }
+
+    if (!initval) { return; }
+    switch (Z_TYPE_P(initval)) {
+       case IS_LONG:
+            mpz_set_si(objval->value, Z_LVAL_P(initval));
+            break;
+       case IS_STRING:
+            mpz_set_str(objval->value, Z_STRVAL_P(initval), 0);
+            break;
+       case IS_DOUBLE:
+            mpz_set_si(objval->value, (zend_long)Z_DVAL_P(initval));
+            break;
+        default:
+            php_error(E_ERROR, "Invalid type supplied");
+   }
 }
 
 static zend_object* mygmp_ctor(zend_class_entry *ce) {

--- a/mygmp.c
+++ b/mygmp.c
@@ -18,11 +18,9 @@ PHP_FUNCTION(mygmp_version) {
     php_printf("%s\n", gmp_version);
 }
 
-PHP_FUNCTION(mygmp_add) {
-    zend_string *retstr, *arg1, *arg2;
+static void do_mygmp_add(zval *return_value, zend_string *arg1, zend_string *arg2) {
+    zend_string *retstr;
     mpz_t ret, num1, num2;
-
-    if (zend_parse_parameters(ZEND_NUM_ARGS(), "PP", &arg1, &arg2) == FAILURE) { return; }
 
     /* Parse text strings into GMP ints */
     mpz_inits(ret, num1, num2, NULL);
@@ -42,6 +40,12 @@ PHP_FUNCTION(mygmp_add) {
     /* Free memory and return */
     mpz_clears(ret, num1, num2, NULL);
     RETURN_STR(retstr);
+}
+
+PHP_FUNCTION(mygmp_add) {
+    zend_string *arg1, *arg2;
+    if (zend_parse_parameters(ZEND_NUM_ARGS(), "PP", &arg1, &arg2) == FAILURE) { return; }
+    do_mygmp_add(return_value, arg1, arg2);
 }
 
 PHP_FUNCTION(mygmp_random_ints) {

--- a/mygmp.c
+++ b/mygmp.c
@@ -76,7 +76,11 @@ PHP_FUNCTION(mygmp_sum) {
     /* foreach ($arr as $val) */
     ZEND_HASH_FOREACH_VAL(arr, val) {
         mpz_t v;
-        zend_string *str = zval_get_string(val); // Provides auto-coersion
+        zend_string *str = zval_try_get_string(val); // Provides auto-coersion
+        if (UNEXPECTED(str == NULL)) {
+            mpz_clear(ret);
+            RETURN_THROWS();
+        }
 
         mpz_init(v);
         if (mpz_set_str(v, ZSTR_VAL(str), 0)) {

--- a/mygmp.c
+++ b/mygmp.c
@@ -48,9 +48,17 @@ PHP_FUNCTION(mygmp_random_ints) {
     zend_long count;
     zend_long bits = sizeof(zend_long) << 3;
 
-    if (zend_parse_parameters(ZEND_NUM_ARGS(), "l|l",
-                              &count, &bits) == FAILURE) {
-        return;
+    if (zend_parse_parameters(ZEND_NUM_ARGS(), "l|l", &count, &bits) == FAILURE) { return; }
+
+    if (count < 0) {
+        php_error(E_WARNING, "Invalid number of random ints requested");
+        RETURN_FALSE;
+    }
+
+    if ((bits < 1) || (bits > (sizeof(zend_long) << 3))) {
+        php_error(E_WARNING, "Invalid bitsize requested, using %ld instead",
+                  sizeof(zend_long) << 3);
+        bits = sizeof(zend_long) << 3;
     }
 
     array_init(return_value);

--- a/mygmp.c
+++ b/mygmp.c
@@ -152,13 +152,13 @@ static zend_result mygmp_init_from_zval(mpz_t val, zval *in) {
        case IS_DOUBLE:
             mpz_set_si(val, (zend_long)Z_DVAL_P(in));
             return SUCCESS;
-        case IS_OBJECT:
+       case IS_OBJECT:
             if (instanceof_function(Z_OBJCE_P(in), mygmp_ce)) {
                 mpz_set(val, mygmp_from_zend_object(Z_OBJ_P(in))->value);
                 return SUCCESS;
             }
             return FAILURE;
-        default:
+       default:
             return FAILURE;
    }
 }

--- a/mygmp.c
+++ b/mygmp.c
@@ -26,7 +26,7 @@ static void do_mygmp_add(zval *return_value, zend_string *arg1, zend_string *arg
     mpz_inits(ret, num1, num2, NULL);
     if (mpz_set_str(num1, ZSTR_VAL(arg1), 0) || mpz_set_str(num2, ZSTR_VAL(arg2), 0)) {
         mpz_clears(ret, num1, num2, NULL);
-        RETURN_FALSE;
+        RETURN_NULL();
     }
 
     /* Perform the operation */
@@ -111,7 +111,7 @@ PHP_FUNCTION(mygmp_random_ints) {
 
     if (count < 0) {
         php_error(E_WARNING, "Invalid number of random ints requested");
-        RETURN_FALSE;
+        RETURN_NULL();
     }
 
     if ((bits < 1) || (bits > (sizeof(zend_long) << 3))) {

--- a/mygmp.c
+++ b/mygmp.c
@@ -44,7 +44,7 @@ static void do_mygmp_add(zval *return_value, zend_string *arg1, zend_string *arg
 
 PHP_FUNCTION(mygmp_add) {
     zend_string *arg1, *arg2;
-    if (zend_parse_parameters(ZEND_NUM_ARGS(), "PP", &arg1, &arg2) == FAILURE) { return; }
+    if (zend_parse_parameters(ZEND_NUM_ARGS(), "PP", &arg1, &arg2) == FAILURE) { RETURN_THROWS(); }
     do_mygmp_add(return_value, arg1, arg2);
 }
 
@@ -52,7 +52,7 @@ PHP_FUNCTION(mygmp_add_array) {
     zend_array *arr;
     zval *a, *b;
 
-    if (zend_parse_parameters(ZEND_NUM_ARGS(), "h", &arr) == FAILURE) { return; }
+    if (zend_parse_parameters(ZEND_NUM_ARGS(), "h", &arr) == FAILURE) { RETURN_THROWS(); }
 
     a = zend_symtable_str_find(arr, "a", strlen("a"));
     b = zend_symtable_str_find(arr, "b", strlen("b"));
@@ -70,7 +70,7 @@ PHP_FUNCTION(mygmp_sum) {
     mpz_t ret;
     zval *val;
 
-    if (zend_parse_parameters(ZEND_NUM_ARGS(), "h", &arr) == FAILURE) { return; }
+    if (zend_parse_parameters(ZEND_NUM_ARGS(), "h", &arr) == FAILURE) { RETURN_THROWS(); }
 
     mpz_init(ret);
     /* foreach ($arr as $val) */
@@ -103,7 +103,7 @@ PHP_FUNCTION(mygmp_random_ints) {
     zend_long count;
     zend_long bits = sizeof(zend_long) << 3;
 
-    if (zend_parse_parameters(ZEND_NUM_ARGS(), "l|l", &count, &bits) == FAILURE) { return; }
+    if (zend_parse_parameters(ZEND_NUM_ARGS(), "l|l", &count, &bits) == FAILURE) { RETURN_THROWS(); }
 
     if (count < 0) {
         php_error(E_WARNING, "Invalid number of random ints requested");
@@ -168,7 +168,7 @@ PHP_METHOD(MyGMP, __construct) {
     zval *initval = NULL;
 
     if (zend_parse_parameters_throw(ZEND_NUM_ARGS(), "|z!", &initval) == FAILURE) {
-        return;
+        RETURN_THROWS();
     }
 
     if (mygmp_init_from_zval(objval->value, initval) == FAILURE) {
@@ -183,7 +183,7 @@ void do_mygmp_arith(mygmp_mpz_arith_t opfunc, INTERNAL_FUNCTION_PARAMETERS) {
     mpz_t other;
     mygmp_object *objval = mygmp_from_zend_object(Z_OBJ_P(getThis()));
 
-    if (zend_parse_parameters(ZEND_NUM_ARGS(), "z", &zother) == FAILURE) { return; }
+    if (zend_parse_parameters(ZEND_NUM_ARGS(), "z", &zother) == FAILURE) { RETURN_THROWS(); }
     mpz_init(other);
     if (mygmp_init_from_zval(other, zother) == FAILURE) {
         php_error(E_ERROR, "Invalid operand");

--- a/mygmp.c
+++ b/mygmp.c
@@ -44,6 +44,22 @@ PHP_FUNCTION(mygmp_add) {
     RETURN_STR(retstr);
 }
 
+PHP_FUNCTION(mygmp_random_ints) {
+    zend_long count;
+    zend_long bits = sizeof(zend_long) << 3;
+
+    if (zend_parse_parameters(ZEND_NUM_ARGS(), "l|l",
+                              &count, &bits) == FAILURE) {
+        return;
+    }
+
+    array_init(return_value);
+    while (count--) {
+        zend_long val = (zend_long)gmp_urandomb_ui(randstate, bits);
+        add_next_index_long(return_value, val);
+    }
+}
+
 static PHP_MINIT_FUNCTION(mygmp) {
     gmp_randinit_mt(randstate);
     return SUCCESS;

--- a/mygmp.c
+++ b/mygmp.c
@@ -48,6 +48,22 @@ PHP_FUNCTION(mygmp_add) {
     do_mygmp_add(return_value, arg1, arg2);
 }
 
+PHP_FUNCTION(mygmp_add_array) {
+    zend_array *arr;
+    zval *a, *b;
+
+    if (zend_parse_parameters(ZEND_NUM_ARGS(), "h", &arr) == FAILURE) { return; }
+
+    a = zend_symtable_str_find(arr, "a", strlen("a"));
+    b = zend_symtable_str_find(arr, "b", strlen("b"));
+    if (!a || (Z_TYPE_P(a) != IS_STRING) || !b || (Z_TYPE_P(b) != IS_STRING)) {
+        php_error(E_WARNING, "Invalid or missing elements");
+        return;
+    }
+
+    do_mygmp_add(return_value, Z_STR_P(a), Z_STR_P(b));
+}
+
 PHP_FUNCTION(mygmp_random_ints) {
     zend_long count;
     zend_long bits = sizeof(zend_long) << 3;

--- a/mygmp.c
+++ b/mygmp.c
@@ -64,6 +64,41 @@ PHP_FUNCTION(mygmp_add_array) {
     do_mygmp_add(return_value, Z_STR_P(a), Z_STR_P(b));
 }
 
+PHP_FUNCTION(mygmp_sum) {
+    zend_array *arr;
+    zend_string *retstr;
+    mpz_t ret;
+    zval *val;
+
+    if (zend_parse_parameters(ZEND_NUM_ARGS(), "h", &arr) == FAILURE) { return; }
+
+    mpz_init(ret);
+    /* foreach ($arr as $val) */
+    ZEND_HASH_FOREACH_VAL(arr, val) {
+        mpz_t v;
+        zend_string *str = zval_get_string(val); // Provides auto-coersion
+
+        mpz_init(v);
+        if (mpz_set_str(v, ZSTR_VAL(str), 0)) {
+            php_error(E_WARNING, "Invalid value: %s", ZSTR_VAL(str));
+            mpz_clear(v);
+            zend_string_release(str);
+            continue;
+        }
+
+        mpz_add(ret, ret, v); // $ret += $v;
+        mpz_clear(v);
+        zend_string_release(str);
+    } ZEND_HASH_FOREACH_END();
+
+    retstr = zend_string_alloc(mpz_sizeinbase(ret, 10), 0);
+    mpz_get_str(ZSTR_VAL(retstr), 10, ret);
+    ZSTR_LEN(retstr) = strlen(ZSTR_VAL(retstr));
+
+    mpz_clear(ret);
+    RETURN_STR(retstr);
+}
+
 PHP_FUNCTION(mygmp_random_ints) {
     zend_long count;
     zend_long bits = sizeof(zend_long) << 3;

--- a/mygmp.c
+++ b/mygmp.c
@@ -33,7 +33,7 @@ static void do_mygmp_add(zval *return_value, zend_string *arg1, zend_string *arg
     mpz_add(ret, num1, num2);
 
     /* Marshal the sum to a string for output */
-    retstr = zend_string_alloc(mpz_sizeinbase(ret, 10), 0);
+    retstr = zend_string_alloc(mpz_sizeinbase(ret, 10), false);
     mpz_get_str(ZSTR_VAL(retstr), 10, ret);
     ZSTR_LEN(retstr) = strlen(ZSTR_VAL(retstr));
 
@@ -95,7 +95,7 @@ PHP_FUNCTION(mygmp_sum) {
         zend_string_release(str);
     } ZEND_HASH_FOREACH_END();
 
-    retstr = zend_string_alloc(mpz_sizeinbase(ret, 10), 0);
+    retstr = zend_string_alloc(mpz_sizeinbase(ret, 10), false);
     mpz_get_str(ZSTR_VAL(retstr), 10, ret);
     ZSTR_LEN(retstr) = strlen(ZSTR_VAL(retstr));
 
@@ -211,7 +211,7 @@ PHP_METHOD(MyGMP, mul) { do_mygmp_arith(mpz_mul, INTERNAL_FUNCTION_PARAM_PASSTHR
 PHP_METHOD(MyGMP, divq) { do_mygmp_arith(mpz_cdiv_q, INTERNAL_FUNCTION_PARAM_PASSTHRU); }
 
 static zend_string* mpz_to_zend_string(mpz_t value, int base) {
-    zend_string *retstr = zend_string_alloc(mpz_sizeinbase(value, base) + 1, 0);
+    zend_string *retstr = zend_string_alloc(mpz_sizeinbase(value, base) + 1, false);
     mpz_get_str(ZSTR_VAL(retstr), base, value);
     ZSTR_LEN(retstr) = strlen(ZSTR_VAL(retstr));
     return retstr;

--- a/mygmp.c
+++ b/mygmp.c
@@ -18,6 +18,32 @@ PHP_FUNCTION(mygmp_version) {
     php_printf("%s\n", gmp_version);
 }
 
+PHP_FUNCTION(mygmp_add) {
+    zend_string *retstr, *arg1, *arg2;
+    mpz_t ret, num1, num2;
+
+    if (zend_parse_parameters(ZEND_NUM_ARGS(), "PP", &arg1, &arg2) == FAILURE) { return; }
+
+    /* Parse text strings into GMP ints */
+    mpz_inits(ret, num1, num2, NULL);
+    if (mpz_set_str(num1, ZSTR_VAL(arg1), 0) || mpz_set_str(num2, ZSTR_VAL(arg2), 0)) {
+        mpz_clears(ret, num1, num2, NULL);
+        RETURN_FALSE;
+    }
+
+    /* Perform the operation */
+    mpz_add(ret, num1, num2);
+
+    /* Marshal the sum to a string for output */
+    retstr = zend_string_alloc(mpz_sizeinbase(ret, 10), 0);
+    mpz_get_str(ZSTR_VAL(retstr), 10, ret);
+    ZSTR_LEN(retstr) = strlen(ZSTR_VAL(retstr));
+
+    /* Free memory and return */
+    mpz_clears(ret, num1, num2, NULL);
+    RETURN_STR(retstr);
+}
+
 static PHP_MINIT_FUNCTION(mygmp) {
     gmp_randinit_mt(randstate);
     return SUCCESS;

--- a/mygmp.c
+++ b/mygmp.c
@@ -161,6 +161,27 @@ PHP_METHOD(MyGMP, __construct) {
    }
 }
 
+static zend_string* mpz_to_zend_string(mpz_t value, int base) {
+    zend_string *retstr = zend_string_alloc(mpz_sizeinbase(value, base) + 1, 0);
+    mpz_get_str(ZSTR_VAL(retstr), base, value);
+    ZSTR_LEN(retstr) = strlen(ZSTR_VAL(retstr));
+    return retstr;
+}
+
+PHP_METHOD(MyGMP, __toString) {
+    mygmp_object *objval = mygmp_from_zend_object(Z_OBJ_P(getThis()));
+    RETURN_STR(mpz_to_zend_string(objval->value, 10));
+}
+
+PHP_METHOD(MyGMP, __debugInfo) {
+    mygmp_object *objval = mygmp_from_zend_object(Z_OBJ_P(getThis()));
+    array_init(return_value);
+    add_index_str(return_value, 2, mpz_to_zend_string(objval->value, 2));
+    add_index_str(return_value, 8, mpz_to_zend_string(objval->value, 8));
+    add_index_str(return_value, 10, mpz_to_zend_string(objval->value, 10));
+    add_index_str(return_value, 16, mpz_to_zend_string(objval->value, 16));
+}
+
 static zend_object* mygmp_ctor(zend_class_entry *ce) {
     mygmp_object *objval = ecalloc(1, sizeof(mygmp_object) + zend_object_properties_size(ce));
     mpz_init(objval->value);

--- a/mygmp.c
+++ b/mygmp.c
@@ -137,6 +137,32 @@ static zend_object* mygmp_to_zend_object(mygmp_object* objval)
 static mygmp_object* mygmp_from_zend_object(zend_object* zobj)
     { return ((mygmp_object*)(zobj + 1)) - 1; }
 
+static zend_result mygmp_init_from_zval(mpz_t val, zval *in) {
+    if (!in) {
+        mpz_set_si(val, 0);
+        return SUCCESS;
+    }
+
+    switch (Z_TYPE_P(in)) {
+       case IS_LONG:
+            mpz_set_si(val, Z_LVAL_P(in));
+            return SUCCESS;
+       case IS_STRING:
+            return mpz_set_str(val, Z_STRVAL_P(in), 0) ? FAILURE : SUCCESS;
+       case IS_DOUBLE:
+            mpz_set_si(val, (zend_long)Z_DVAL_P(in));
+            return SUCCESS;
+        case IS_OBJECT:
+            if (instanceof_function(Z_OBJCE_P(in), mygmp_ce)) {
+                mpz_set(val, mygmp_from_zend_object(Z_OBJ_P(in))->value);
+                return SUCCESS;
+            }
+            return FAILURE;
+        default:
+            return FAILURE;
+   }
+}
+
 PHP_METHOD(MyGMP, __construct) {
     mygmp_object *objval = mygmp_from_zend_object(Z_OBJ_P(getThis()));
     zval *initval = NULL;
@@ -145,21 +171,35 @@ PHP_METHOD(MyGMP, __construct) {
         return;
     }
 
-    if (!initval) { return; }
-    switch (Z_TYPE_P(initval)) {
-       case IS_LONG:
-            mpz_set_si(objval->value, Z_LVAL_P(initval));
-            break;
-       case IS_STRING:
-            mpz_set_str(objval->value, Z_STRVAL_P(initval), 0);
-            break;
-       case IS_DOUBLE:
-            mpz_set_si(objval->value, (zend_long)Z_DVAL_P(initval));
-            break;
-        default:
-            php_error(E_ERROR, "Invalid type supplied");
-   }
+    if (mygmp_init_from_zval(objval->value, initval) == FAILURE) {
+        php_error(E_ERROR, "Failed initalizing MyGMP object");
+        return;
+    }
 }
+
+typedef void(*mygmp_mpz_arith_t)(mpz_t rop, const mpz_t op1, const mpz_t op2);
+void do_mygmp_arith(mygmp_mpz_arith_t opfunc, INTERNAL_FUNCTION_PARAMETERS) {
+    zval *zother;
+    mpz_t other;
+    mygmp_object *objval = mygmp_from_zend_object(Z_OBJ_P(getThis()));
+
+    if (zend_parse_parameters(ZEND_NUM_ARGS(), "z", &zother) == FAILURE) { return; }
+    mpz_init(other);
+    if (mygmp_init_from_zval(other, zother) == FAILURE) {
+        php_error(E_ERROR, "Invalid operand");
+        mpz_clear(other);
+        return;
+    }
+
+    object_init_ex(return_value, mygmp_ce);
+    opfunc(mygmp_from_zend_object(Z_OBJ_P(return_value))->value, objval->value, other);
+    mpz_clear(other);
+}
+
+PHP_METHOD(MyGMP, add) { do_mygmp_arith(mpz_add, INTERNAL_FUNCTION_PARAM_PASSTHRU); }
+PHP_METHOD(MyGMP, sub) { do_mygmp_arith(mpz_sub, INTERNAL_FUNCTION_PARAM_PASSTHRU); }
+PHP_METHOD(MyGMP, mul) { do_mygmp_arith(mpz_mul, INTERNAL_FUNCTION_PARAM_PASSTHRU); }
+PHP_METHOD(MyGMP, divq) { do_mygmp_arith(mpz_cdiv_q, INTERNAL_FUNCTION_PARAM_PASSTHRU); }
 
 static zend_string* mpz_to_zend_string(mpz_t value, int base) {
     zend_string *retstr = zend_string_alloc(mpz_sizeinbase(value, base) + 1, 0);

--- a/mygmp.stub.php
+++ b/mygmp.stub.php
@@ -7,5 +7,6 @@ function mygmp_version(): void {}
 function mygmp_get_version(): string {}
 
 function mygmp_add(string $a, string $b): string|false {}
+function mygmp_add_array(array $arr): string|false {}
 
 function mygmp_random_ints(int $count, int $bits = 64): array|false {}

--- a/mygmp.stub.php
+++ b/mygmp.stub.php
@@ -7,3 +7,5 @@ function mygmp_version(): void {}
 function mygmp_get_version(): string {}
 
 function mygmp_add(string $a, string $b): string|false {}
+
+function mygmp_random_ints(int $count, int $bits = 64): array {}

--- a/mygmp.stub.php
+++ b/mygmp.stub.php
@@ -20,4 +20,9 @@ class MyGMP {
     public function __construct(int|float|string $num = 0) {}
     public function __toString(): string {}
     public function __debugInfo(): array {}
+
+    public function add(\MyGMP|int|float|string $other): \MyGMP {}
+    public function sub(\MyGMP|int|float|string $other): \MyGMP {}
+    public function mul(\MyGMP|int|float|string $other): \MyGMP {}
+    public function divq(\MyGMP|int|float|string $other): \MyGMP {}
 }

--- a/mygmp.stub.php
+++ b/mygmp.stub.php
@@ -10,7 +10,7 @@ function mygmp_version(): void {}
 function mygmp_get_version(): string {}
 
 function mygmp_add(string $a, string $b): string|false {}
-function mygmp_add_array(array $arr): string {}
+function mygmp_add_array(array $arr): string|null {}
 
 function mygmp_sum(array $nums): string|false {}
 

--- a/mygmp.stub.php
+++ b/mygmp.stub.php
@@ -1,6 +1,9 @@
 <?php
 
-/** @generate-function-entries */
+/**
+ * @generate-function-entries
+ * @generate-class-entries
+ */
 
 function mygmp_version(): void {}
 
@@ -12,3 +15,7 @@ function mygmp_add_array(array $arr): string {}
 function mygmp_sum(array $nums): string|false {}
 
 function mygmp_random_ints(int $count, int $bits = 64): array|false {}
+
+class MyGMP {
+    public function __construct(int|float|string $num = 0) {}
+}

--- a/mygmp.stub.php
+++ b/mygmp.stub.php
@@ -7,6 +7,8 @@ function mygmp_version(): void {}
 function mygmp_get_version(): string {}
 
 function mygmp_add(string $a, string $b): string|false {}
-function mygmp_add_array(array $arr): string|false {}
+function mygmp_add_array(array $arr): string {}
+
+function mygmp_sum(array $nums): string|false {}
 
 function mygmp_random_ints(int $count, int $bits = 64): array|false {}

--- a/mygmp.stub.php
+++ b/mygmp.stub.php
@@ -8,4 +8,4 @@ function mygmp_get_version(): string {}
 
 function mygmp_add(string $a, string $b): string|false {}
 
-function mygmp_random_ints(int $count, int $bits = 64): array {}
+function mygmp_random_ints(int $count, int $bits = 64): array|false {}

--- a/mygmp.stub.php
+++ b/mygmp.stub.php
@@ -5,3 +5,5 @@
 function mygmp_version(): void {}
 
 function mygmp_get_version(): string {}
+
+function mygmp_add(string $a, string $b): string|false {}

--- a/mygmp.stub.php
+++ b/mygmp.stub.php
@@ -18,4 +18,6 @@ function mygmp_random_ints(int $count, int $bits = 64): array|false {}
 
 class MyGMP {
     public function __construct(int|float|string $num = 0) {}
+    public function __toString(): string {}
+    public function __debugInfo(): array {}
 }

--- a/mygmp.stub.php
+++ b/mygmp.stub.php
@@ -9,12 +9,12 @@ function mygmp_version(): void {}
 
 function mygmp_get_version(): string {}
 
-function mygmp_add(string $a, string $b): string|false {}
+function mygmp_add(string $a, string $b): string|null {}
 function mygmp_add_array(array $arr): string|null {}
 
-function mygmp_sum(array $nums): string|false {}
+function mygmp_sum(array $nums): string|null {}
 
-function mygmp_random_ints(int $count, int $bits = 64): array|false {}
+function mygmp_random_ints(int $count, int $bits = 64): array|null {}
 
 class MyGMP {
     public function __construct(int|float|string $num = 0) {}

--- a/mygmp_arginfo.h
+++ b/mygmp_arginfo.h
@@ -1,5 +1,5 @@
 /* This is a generated file, edit the .stub.php file instead.
- * Stub hash: 65f15bc42e4bbde48854c2489057ffed3396e723 */
+ * Stub hash: aab64f42d9105fcc18c786a8c346b70958079222 */
 
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_mygmp_version, 0, 0, IS_VOID, 0)
 ZEND_END_ARG_INFO()
@@ -12,13 +12,20 @@ ZEND_BEGIN_ARG_WITH_RETURN_TYPE_MASK_EX(arginfo_mygmp_add, 0, 2, MAY_BE_STRING|M
 	ZEND_ARG_TYPE_INFO(0, b, IS_STRING, 0)
 ZEND_END_ARG_INFO()
 
+ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_mygmp_random_ints, 0, 1, IS_ARRAY, 0)
+	ZEND_ARG_TYPE_INFO(0, count, IS_LONG, 0)
+	ZEND_ARG_TYPE_INFO_WITH_DEFAULT_VALUE(0, bits, IS_LONG, 0, "64")
+ZEND_END_ARG_INFO()
+
 ZEND_FUNCTION(mygmp_version);
 ZEND_FUNCTION(mygmp_get_version);
 ZEND_FUNCTION(mygmp_add);
+ZEND_FUNCTION(mygmp_random_ints);
 
 static const zend_function_entry ext_functions[] = {
 	ZEND_FE(mygmp_version, arginfo_mygmp_version)
 	ZEND_FE(mygmp_get_version, arginfo_mygmp_get_version)
 	ZEND_FE(mygmp_add, arginfo_mygmp_add)
+	ZEND_FE(mygmp_random_ints, arginfo_mygmp_random_ints)
 	ZEND_FE_END
 };

--- a/mygmp_arginfo.h
+++ b/mygmp_arginfo.h
@@ -1,5 +1,5 @@
 /* This is a generated file, edit the .stub.php file instead.
- * Stub hash: bc8fe8c8f96da45bac2bd57a7b3a57fbdebc30e6 */
+ * Stub hash: 818822aa1ab5369157e409a2a0a657f334aeb369 */
 
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_mygmp_version, 0, 0, IS_VOID, 0)
 ZEND_END_ARG_INFO()
@@ -25,12 +25,17 @@ ZEND_BEGIN_ARG_WITH_RETURN_TYPE_MASK_EX(arginfo_mygmp_random_ints, 0, 1, MAY_BE_
 	ZEND_ARG_TYPE_INFO_WITH_DEFAULT_VALUE(0, bits, IS_LONG, 0, "64")
 ZEND_END_ARG_INFO()
 
+ZEND_BEGIN_ARG_INFO_EX(arginfo_class_MyGMP___construct, 0, 0, 0)
+	ZEND_ARG_TYPE_MASK(0, num, MAY_BE_LONG|MAY_BE_DOUBLE|MAY_BE_STRING, "0")
+ZEND_END_ARG_INFO()
+
 ZEND_FUNCTION(mygmp_version);
 ZEND_FUNCTION(mygmp_get_version);
 ZEND_FUNCTION(mygmp_add);
 ZEND_FUNCTION(mygmp_add_array);
 ZEND_FUNCTION(mygmp_sum);
 ZEND_FUNCTION(mygmp_random_ints);
+ZEND_METHOD(MyGMP, __construct);
 
 static const zend_function_entry ext_functions[] = {
 	ZEND_FE(mygmp_version, arginfo_mygmp_version)
@@ -41,3 +46,18 @@ static const zend_function_entry ext_functions[] = {
 	ZEND_FE(mygmp_random_ints, arginfo_mygmp_random_ints)
 	ZEND_FE_END
 };
+
+static const zend_function_entry class_MyGMP_methods[] = {
+	ZEND_ME(MyGMP, __construct, arginfo_class_MyGMP___construct, ZEND_ACC_PUBLIC)
+	ZEND_FE_END
+};
+
+static zend_class_entry *register_class_MyGMP(void)
+{
+	zend_class_entry ce, *class_entry;
+
+	INIT_CLASS_ENTRY(ce, "MyGMP", class_MyGMP_methods);
+	class_entry = zend_register_internal_class_with_flags(&ce, NULL, 0);
+
+	return class_entry;
+}

--- a/mygmp_arginfo.h
+++ b/mygmp_arginfo.h
@@ -1,5 +1,5 @@
 /* This is a generated file, edit the .stub.php file instead.
- * Stub hash: 9ce612fea26c670390b82703ae6a712a7759e3c3 */
+ * Stub hash: bc8fe8c8f96da45bac2bd57a7b3a57fbdebc30e6 */
 
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_mygmp_version, 0, 0, IS_VOID, 0)
 ZEND_END_ARG_INFO()
@@ -12,8 +12,12 @@ ZEND_BEGIN_ARG_WITH_RETURN_TYPE_MASK_EX(arginfo_mygmp_add, 0, 2, MAY_BE_STRING|M
 	ZEND_ARG_TYPE_INFO(0, b, IS_STRING, 0)
 ZEND_END_ARG_INFO()
 
-ZEND_BEGIN_ARG_WITH_RETURN_TYPE_MASK_EX(arginfo_mygmp_add_array, 0, 1, MAY_BE_STRING|MAY_BE_FALSE)
+ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_mygmp_add_array, 0, 1, IS_STRING, 0)
 	ZEND_ARG_TYPE_INFO(0, arr, IS_ARRAY, 0)
+ZEND_END_ARG_INFO()
+
+ZEND_BEGIN_ARG_WITH_RETURN_TYPE_MASK_EX(arginfo_mygmp_sum, 0, 1, MAY_BE_STRING|MAY_BE_FALSE)
+	ZEND_ARG_TYPE_INFO(0, nums, IS_ARRAY, 0)
 ZEND_END_ARG_INFO()
 
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_MASK_EX(arginfo_mygmp_random_ints, 0, 1, MAY_BE_ARRAY|MAY_BE_FALSE)
@@ -25,6 +29,7 @@ ZEND_FUNCTION(mygmp_version);
 ZEND_FUNCTION(mygmp_get_version);
 ZEND_FUNCTION(mygmp_add);
 ZEND_FUNCTION(mygmp_add_array);
+ZEND_FUNCTION(mygmp_sum);
 ZEND_FUNCTION(mygmp_random_ints);
 
 static const zend_function_entry ext_functions[] = {
@@ -32,6 +37,7 @@ static const zend_function_entry ext_functions[] = {
 	ZEND_FE(mygmp_get_version, arginfo_mygmp_get_version)
 	ZEND_FE(mygmp_add, arginfo_mygmp_add)
 	ZEND_FE(mygmp_add_array, arginfo_mygmp_add_array)
+	ZEND_FE(mygmp_sum, arginfo_mygmp_sum)
 	ZEND_FE(mygmp_random_ints, arginfo_mygmp_random_ints)
 	ZEND_FE_END
 };

--- a/mygmp_arginfo.h
+++ b/mygmp_arginfo.h
@@ -1,5 +1,5 @@
 /* This is a generated file, edit the .stub.php file instead.
- * Stub hash: d7d10caca50cf525b2ad6327bd21c3f5896d6ebd */
+ * Stub hash: 60d9514c956adab803ee5cb66930fcf47e92150b */
 
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_mygmp_version, 0, 0, IS_VOID, 0)
 ZEND_END_ARG_INFO()
@@ -34,6 +34,16 @@ ZEND_END_ARG_INFO()
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_class_MyGMP___debugInfo, 0, 0, IS_ARRAY, 0)
 ZEND_END_ARG_INFO()
 
+ZEND_BEGIN_ARG_WITH_RETURN_OBJ_INFO_EX(arginfo_class_MyGMP_add, 0, 1, MyGMP, 0)
+	ZEND_ARG_OBJ_TYPE_MASK(0, other, MyGMP, MAY_BE_LONG|MAY_BE_DOUBLE|MAY_BE_STRING, NULL)
+ZEND_END_ARG_INFO()
+
+#define arginfo_class_MyGMP_sub arginfo_class_MyGMP_add
+
+#define arginfo_class_MyGMP_mul arginfo_class_MyGMP_add
+
+#define arginfo_class_MyGMP_divq arginfo_class_MyGMP_add
+
 ZEND_FUNCTION(mygmp_version);
 ZEND_FUNCTION(mygmp_get_version);
 ZEND_FUNCTION(mygmp_add);
@@ -43,6 +53,10 @@ ZEND_FUNCTION(mygmp_random_ints);
 ZEND_METHOD(MyGMP, __construct);
 ZEND_METHOD(MyGMP, __toString);
 ZEND_METHOD(MyGMP, __debugInfo);
+ZEND_METHOD(MyGMP, add);
+ZEND_METHOD(MyGMP, sub);
+ZEND_METHOD(MyGMP, mul);
+ZEND_METHOD(MyGMP, divq);
 
 static const zend_function_entry ext_functions[] = {
 	ZEND_FE(mygmp_version, arginfo_mygmp_version)
@@ -58,6 +72,10 @@ static const zend_function_entry class_MyGMP_methods[] = {
 	ZEND_ME(MyGMP, __construct, arginfo_class_MyGMP___construct, ZEND_ACC_PUBLIC)
 	ZEND_ME(MyGMP, __toString, arginfo_class_MyGMP___toString, ZEND_ACC_PUBLIC)
 	ZEND_ME(MyGMP, __debugInfo, arginfo_class_MyGMP___debugInfo, ZEND_ACC_PUBLIC)
+	ZEND_ME(MyGMP, add, arginfo_class_MyGMP_add, ZEND_ACC_PUBLIC)
+	ZEND_ME(MyGMP, sub, arginfo_class_MyGMP_sub, ZEND_ACC_PUBLIC)
+	ZEND_ME(MyGMP, mul, arginfo_class_MyGMP_mul, ZEND_ACC_PUBLIC)
+	ZEND_ME(MyGMP, divq, arginfo_class_MyGMP_divq, ZEND_ACC_PUBLIC)
 	ZEND_FE_END
 };
 

--- a/mygmp_arginfo.h
+++ b/mygmp_arginfo.h
@@ -1,5 +1,5 @@
 /* This is a generated file, edit the .stub.php file instead.
- * Stub hash: a8239839f63af1d19ce92de53d3ae50396f0a970 */
+ * Stub hash: 65f15bc42e4bbde48854c2489057ffed3396e723 */
 
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_mygmp_version, 0, 0, IS_VOID, 0)
 ZEND_END_ARG_INFO()
@@ -7,11 +7,18 @@ ZEND_END_ARG_INFO()
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_mygmp_get_version, 0, 0, IS_STRING, 0)
 ZEND_END_ARG_INFO()
 
+ZEND_BEGIN_ARG_WITH_RETURN_TYPE_MASK_EX(arginfo_mygmp_add, 0, 2, MAY_BE_STRING|MAY_BE_FALSE)
+	ZEND_ARG_TYPE_INFO(0, a, IS_STRING, 0)
+	ZEND_ARG_TYPE_INFO(0, b, IS_STRING, 0)
+ZEND_END_ARG_INFO()
+
 ZEND_FUNCTION(mygmp_version);
 ZEND_FUNCTION(mygmp_get_version);
+ZEND_FUNCTION(mygmp_add);
 
 static const zend_function_entry ext_functions[] = {
 	ZEND_FE(mygmp_version, arginfo_mygmp_version)
 	ZEND_FE(mygmp_get_version, arginfo_mygmp_get_version)
+	ZEND_FE(mygmp_add, arginfo_mygmp_add)
 	ZEND_FE_END
 };

--- a/mygmp_arginfo.h
+++ b/mygmp_arginfo.h
@@ -1,5 +1,5 @@
 /* This is a generated file, edit the .stub.php file instead.
- * Stub hash: aab64f42d9105fcc18c786a8c346b70958079222 */
+ * Stub hash: 1b000ff932ed646aab298cd6fdf22ce9ee1c6af8 */
 
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_mygmp_version, 0, 0, IS_VOID, 0)
 ZEND_END_ARG_INFO()
@@ -12,7 +12,7 @@ ZEND_BEGIN_ARG_WITH_RETURN_TYPE_MASK_EX(arginfo_mygmp_add, 0, 2, MAY_BE_STRING|M
 	ZEND_ARG_TYPE_INFO(0, b, IS_STRING, 0)
 ZEND_END_ARG_INFO()
 
-ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_mygmp_random_ints, 0, 1, IS_ARRAY, 0)
+ZEND_BEGIN_ARG_WITH_RETURN_TYPE_MASK_EX(arginfo_mygmp_random_ints, 0, 1, MAY_BE_ARRAY|MAY_BE_FALSE)
 	ZEND_ARG_TYPE_INFO(0, count, IS_LONG, 0)
 	ZEND_ARG_TYPE_INFO_WITH_DEFAULT_VALUE(0, bits, IS_LONG, 0, "64")
 ZEND_END_ARG_INFO()

--- a/mygmp_arginfo.h
+++ b/mygmp_arginfo.h
@@ -1,5 +1,5 @@
 /* This is a generated file, edit the .stub.php file instead.
- * Stub hash: 818822aa1ab5369157e409a2a0a657f334aeb369 */
+ * Stub hash: d7d10caca50cf525b2ad6327bd21c3f5896d6ebd */
 
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_mygmp_version, 0, 0, IS_VOID, 0)
 ZEND_END_ARG_INFO()
@@ -29,6 +29,11 @@ ZEND_BEGIN_ARG_INFO_EX(arginfo_class_MyGMP___construct, 0, 0, 0)
 	ZEND_ARG_TYPE_MASK(0, num, MAY_BE_LONG|MAY_BE_DOUBLE|MAY_BE_STRING, "0")
 ZEND_END_ARG_INFO()
 
+#define arginfo_class_MyGMP___toString arginfo_mygmp_get_version
+
+ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_class_MyGMP___debugInfo, 0, 0, IS_ARRAY, 0)
+ZEND_END_ARG_INFO()
+
 ZEND_FUNCTION(mygmp_version);
 ZEND_FUNCTION(mygmp_get_version);
 ZEND_FUNCTION(mygmp_add);
@@ -36,6 +41,8 @@ ZEND_FUNCTION(mygmp_add_array);
 ZEND_FUNCTION(mygmp_sum);
 ZEND_FUNCTION(mygmp_random_ints);
 ZEND_METHOD(MyGMP, __construct);
+ZEND_METHOD(MyGMP, __toString);
+ZEND_METHOD(MyGMP, __debugInfo);
 
 static const zend_function_entry ext_functions[] = {
 	ZEND_FE(mygmp_version, arginfo_mygmp_version)
@@ -49,6 +56,8 @@ static const zend_function_entry ext_functions[] = {
 
 static const zend_function_entry class_MyGMP_methods[] = {
 	ZEND_ME(MyGMP, __construct, arginfo_class_MyGMP___construct, ZEND_ACC_PUBLIC)
+	ZEND_ME(MyGMP, __toString, arginfo_class_MyGMP___toString, ZEND_ACC_PUBLIC)
+	ZEND_ME(MyGMP, __debugInfo, arginfo_class_MyGMP___debugInfo, ZEND_ACC_PUBLIC)
 	ZEND_FE_END
 };
 

--- a/mygmp_arginfo.h
+++ b/mygmp_arginfo.h
@@ -1,5 +1,5 @@
 /* This is a generated file, edit the .stub.php file instead.
- * Stub hash: 1b000ff932ed646aab298cd6fdf22ce9ee1c6af8 */
+ * Stub hash: 9ce612fea26c670390b82703ae6a712a7759e3c3 */
 
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_mygmp_version, 0, 0, IS_VOID, 0)
 ZEND_END_ARG_INFO()
@@ -12,6 +12,10 @@ ZEND_BEGIN_ARG_WITH_RETURN_TYPE_MASK_EX(arginfo_mygmp_add, 0, 2, MAY_BE_STRING|M
 	ZEND_ARG_TYPE_INFO(0, b, IS_STRING, 0)
 ZEND_END_ARG_INFO()
 
+ZEND_BEGIN_ARG_WITH_RETURN_TYPE_MASK_EX(arginfo_mygmp_add_array, 0, 1, MAY_BE_STRING|MAY_BE_FALSE)
+	ZEND_ARG_TYPE_INFO(0, arr, IS_ARRAY, 0)
+ZEND_END_ARG_INFO()
+
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_MASK_EX(arginfo_mygmp_random_ints, 0, 1, MAY_BE_ARRAY|MAY_BE_FALSE)
 	ZEND_ARG_TYPE_INFO(0, count, IS_LONG, 0)
 	ZEND_ARG_TYPE_INFO_WITH_DEFAULT_VALUE(0, bits, IS_LONG, 0, "64")
@@ -20,12 +24,14 @@ ZEND_END_ARG_INFO()
 ZEND_FUNCTION(mygmp_version);
 ZEND_FUNCTION(mygmp_get_version);
 ZEND_FUNCTION(mygmp_add);
+ZEND_FUNCTION(mygmp_add_array);
 ZEND_FUNCTION(mygmp_random_ints);
 
 static const zend_function_entry ext_functions[] = {
 	ZEND_FE(mygmp_version, arginfo_mygmp_version)
 	ZEND_FE(mygmp_get_version, arginfo_mygmp_get_version)
 	ZEND_FE(mygmp_add, arginfo_mygmp_add)
+	ZEND_FE(mygmp_add_array, arginfo_mygmp_add_array)
 	ZEND_FE(mygmp_random_ints, arginfo_mygmp_random_ints)
 	ZEND_FE_END
 };


### PR DESCRIPTION
Commits are individualized for each item.

Note: the `mpz_set_str()` with a base of `0` will *not* parse a string prefixed with an explicit octal prefix, e.g. `0o14` corresponding to `014` (12 in base 10)